### PR TITLE
Fix: Correct token manager check in complete_demo.py

### DIFF
--- a/examples/complete_demo.py
+++ b/examples/complete_demo.py
@@ -74,15 +74,18 @@ class PCloudDemo:
         )
 
         # Check if we have saved credentials
-        if self.sdk.app.token_manager and self.sdk.app.token_manager.has_valid_token():
-            print("🔑 Using saved credentials...")
+        # PCloudSDK's __init__ already attempts to load token if token_manager is True
+        if self.sdk.token_manager_enabled and self.sdk.app.get_access_token():
+            print("🔑 Attempting to use saved credentials...")
             try:
-                # Test the existing token
+                # Test the existing token by fetching user info
                 user_info = self.sdk.user.get_user_info()
-                print(f"✅ Successfully authenticated as: {user_info.get('email')}")
+                print(f"✅ Successfully authenticated using saved credentials as: {user_info.get('email')}")
                 return True
-            except Exception as e:
-                print(f"⚠️ Saved credentials expired: {e}")
+            except PCloudException as e: # Specifically catch PCloudException for auth/API errors
+                print(f"⚠️ Saved credentials might be invalid or expired: {e}")
+            except Exception as e: # Catch any other unexpected errors during the test
+                print(f"⚠️ An unexpected error occurred while using saved credentials: {e}")
 
         # Need fresh authentication
         print("\n🔐 Authentication Required")


### PR DESCRIPTION
The `examples/complete_demo.py` script was attempting to access `sdk.app.token_manager`, which does not exist. The `App` object does not have a `token_manager` attribute.

This commit updates the script to correctly check for token management capabilities and loaded tokens by:
- Verifying `sdk.token_manager_enabled` (an attribute of `PCloudSDK`).
- Checking `sdk.app.get_access_token()` (to see if a token was loaded by `PCloudSDK`'s initialization process).

This resolves the AttributeError and allows the demo to proceed to authentication if no valid saved token is found.